### PR TITLE
Fix for settings page reload

### DIFF
--- a/app/components/settings/SettingsPage.js
+++ b/app/components/settings/SettingsPage.js
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import {bindActionCreators} from 'redux';
+// import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import * as settingsActions from '../../actions/settingsActions';
 import Config from './Configuration';
@@ -30,8 +30,8 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(settingsActions, dispatch);
-}
+// function mapDispatchToProps(dispatch) {
+//   return bindActionCreators(settingsActions, dispatch);
+// }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Settings);
+export default connect(mapStateToProps)(Settings);

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -5,9 +5,9 @@ import settings from './settingsReducer';
 import ajaxCallsInProgress from './ajaxStatusReducer';
 
 const rootReducer = combineReducers({
-  data,
-  settings,
   routing,
+  settings,
+  data,
   ajaxCallsInProgress
 });
 

--- a/app/reducers/initialState.js
+++ b/app/reducers/initialState.js
@@ -1,5 +1,27 @@
 export default {
   data: [],
-  settings: {},
+  settings: {
+    logLevel: '',
+    port: '',
+    modules: {
+      system: {status: ''},
+      cpu: {status: '', interval: ''},
+      processes: {status: '', interval: ''},
+      memory: {status: '', interval: ''},
+      temperature: {status: '', interval: ''},
+      fan: {status: '', interval: ''},
+      battery: {status: '', interval: ''},
+      disk: {status: '', interval: ''},
+      diskfs: {status: '', interval: ''},
+      network: {status: '', interval: '', iface: '', ping: ''},
+      netConnections: {status: '', interval: ''}
+    },
+    db: {
+      rethinkdb: {status: '', host: '', port: '', authKey: '', dbname: ''},
+      postgres: {status: '', host: '', port: '', user: '', pass: '', dbname: ''},
+      pouchdb: {status: ''},
+      couchdb: {status: '', host: '', port: '', dbname: '', ssl: ''}
+    }
+  },
   ajaxCallsInProgress: 0
 };


### PR DESCRIPTION
Fixed initialState for reloading on the settings page by adding the full settings object layout with null values to initial state.

```
export default {
  data: [],
  settings: {
    logLevel: '',
    port: '',
    modules: {
      system: {status: ''},
      cpu: {status: '', interval: ''},
      processes: {status: '', interval: ''},
      memory: {status: '', interval: ''},
      temperature: {status: '', interval: ''},
      fan: {status: '', interval: ''},
      battery: {status: '', interval: ''},
      disk: {status: '', interval: ''},
      diskfs: {status: '', interval: ''},
      network: {status: '', interval: '', iface: '', ping: ''},
      netConnections: {status: '', interval: ''}
    },
    db: {
      rethinkdb: {status: '', host: '', port: '', authKey: '', dbname: ''},
      postgres: {status: '', host: '', port: '', user: '', pass: '', dbname: ''},
      pouchdb: {status: ''},
      couchdb: {status: '', host: '', port: '', dbname: '', ssl: ''}
    }
  },
  ajaxCallsInProgress: 0
};
```