### PR TITLE
fix for settings page updating backend settings

### DIFF
--- a/server/controllers/cpu.js
+++ b/server/controllers/cpu.js
@@ -1,23 +1,23 @@
 const si = require('systeminformation'),
       winston = require('../services/winston'),
-      settings = require('../services/settings'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       pdb = require('../db/pouchdb');
 
-if (settings.config.modules.cpu.status) {
+if (settings.modules.cpu.status) {
   let module = 'cpu';
   setInterval(() => {
     si.cpuCurrentspeed()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop)) {
                 if (typeof(data[prop]) === 'boolean') {
@@ -38,14 +38,14 @@ if (settings.config.modules.cpu.status) {
 
     si.currentLoad()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop) && !data[prop] instanceof Array) {
                 if (typeof(data[prop]) === 'boolean') {
@@ -80,14 +80,14 @@ if (settings.config.modules.cpu.status) {
 
     si.fullLoad()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             let values = {
               name: module +'.'+ 'fullLoad',
               value: data
@@ -100,15 +100,15 @@ if (settings.config.modules.cpu.status) {
 
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.cpu.interval);
+  }, settings.modules.cpu.interval);
 }
 
 
-if (settings.config.modules.processes.status) {
+if (settings.modules.processes.status) {
   setInterval(() => {
     si.processes()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
@@ -117,7 +117,7 @@ if (settings.config.modules.processes.status) {
           }
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.processes.interval);
+  }, settings.modules.processes.interval);
 }
 
 exports.getServices = si.services;

--- a/server/controllers/disk.js
+++ b/server/controllers/disk.js
@@ -1,23 +1,23 @@
 const si = require('systeminformation'),
-      settings = require('../services/settings'),
       winston = require('../services/winston'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       pdb = require('../db/pouchdb');
 
-if (settings.config.modules.disk.status) {
+if (settings.modules.disk.status) {
   let module = 'disk';
   setInterval(() => {
     si.fsStats()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop) && data[prop] > -1) {
                 let values = {
@@ -35,14 +35,14 @@ if (settings.config.modules.disk.status) {
         .catch(error => winston.log.error(error));
     si.disksIO()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop) && data[prop] > -1) {
                 let values = {
@@ -57,22 +57,22 @@ if (settings.config.modules.disk.status) {
           }
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.disk.interval)
+  }, settings.modules.disk.interval)
 }
 
-if (settings.config.modules.diskfs.status) {
+if (settings.modules.diskfs.status) {
   let module = 'diskfs'
   setInterval(() => {
     si.fsSize()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             data.forEach(el => {
               for (let prop in el) {
                 if (el.hasOwnProperty(prop) && prop !== 'fs' && prop !== 'type' && prop !== 'mount') {
@@ -89,5 +89,5 @@ if (settings.config.modules.diskfs.status) {
           })
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.diskfs.interval);
+  }, settings.modules.diskfs.interval);
 }

--- a/server/controllers/memory.js
+++ b/server/controllers/memory.js
@@ -1,23 +1,23 @@
 const si = require('systeminformation'),
-      settings = require('../services/settings'),
       winston = require('../services/winston'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       pdb = require('../db/pouchdb');
 
-if (settings.config.modules.memory.status) {
+if (settings.modules.memory.status) {
   let module = 'memory';
   setInterval(() => {
     si.mem()
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop)) {
                 let values = {
@@ -32,5 +32,5 @@ if (settings.config.modules.memory.status) {
           }
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.memory.interval)
+  }, settings.modules.memory.interval)
 }

--- a/server/controllers/network.js
+++ b/server/controllers/network.js
@@ -1,25 +1,25 @@
 const si = require('systeminformation'),
       os = require('os'),
-      settings = require('../services/settings'),
       winston = require('../services/winston'),
       getip = require('../services/getip'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       pdb = require('../db/pouchdb');
 
-if (settings.config.modules.network.status) {
+if (settings.modules.network.status) {
   let module = 'network';
   setInterval(() => {
-    si.networkStats(settings.config.modules.network.iface)
+    si.networkStats(settings.modules.network.iface)
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             for (let prop in data) {
               if (data.hasOwnProperty(prop) && data[prop] > -1 && prop !== 'iface' && prop !== 'operstate') {
                 let values = {
@@ -35,16 +35,16 @@ if (settings.config.modules.network.status) {
           }
         })
         .catch(error => winston.log.error(error));
-    si.inetLatency(settings.config.modules.network.ping)
+    si.inetLatency(settings.modules.network.ping)
         .then(data => {
-          if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+          if (settings.db.pouchdb.status || settings.db.couchdb.status) {
             let obj = {};
             obj.time = new Date().getTime();
             obj.name = module;
             obj.value = data;
             pdb.store(obj);
           }
-          if (settings.config.db.postgres.status) {
+          if (settings.db.postgres.status) {
             let values = {
               name: module +'.latency',
               value: data
@@ -55,22 +55,22 @@ if (settings.config.modules.network.status) {
           }
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.network.interval);
+  }, settings.modules.network.interval);
 }
 
-if (settings.config.modules.netConnections.status) {
+if (settings.modules.netConnections.status) {
   let module = 'netConnections';
   setInterval(() => {
   si.networkConnections()
       .then(data => {
-        if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+        if (settings.db.pouchdb.status || settings.db.couchdb.status) {
           let obj = {};
           obj.time = new Date().getTime();
           obj.name = module;
           obj.value = data;
           pdb.store(obj);
         }
-        if (settings.config.db.postgres.status) {
+        if (settings.db.postgres.status) {
           data.forEach((el, i) => {
             for (let prop in el) {
               if (el.hasOwnProperty(prop)) {
@@ -115,7 +115,7 @@ if (settings.config.modules.netConnections.status) {
       })
       .catch(error => winston.log.error(error));
 
-  }, settings.config.modules.netConnections.interval);
+  }, settings.modules.netConnections.interval);
 }
 
 exports.getPublicIp = getip.v4;

--- a/server/controllers/system.js
+++ b/server/controllers/system.js
@@ -1,25 +1,25 @@
 const os = require('os'),
       si = require('systeminformation'),
       winston = require('../services/winston'),
-      settings = require('../services/settings'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       pdb = require('../db/pouchdb');
 
-if (settings.config.modules.battery.status) {
+if (settings.modules.battery.status) {
   let module = 'battery';
   setInterval(() => {
     si.battery()
         .then(data => {
           if (data.hasbattery) {
-            if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+            if (settings.db.pouchdb.status || settings.db.couchdb.status) {
               let obj = {};
               obj.time = new Date().getTime();
               obj.name = module;
               obj.value = data;
               pdb.store(obj);
             }
-            if (settings.config.db.postgres.status) {
+            if (settings.db.postgres.status) {
               for (let prop in data) {
                 if (data.hasOwnProperty(prop) && prop !== 'hasbattery') {
                   if (typeof(data[prop]) === 'boolean') {
@@ -39,7 +39,7 @@ if (settings.config.modules.battery.status) {
           }
         })
         .catch(error => winston.log.error(error));
-  }, settings.config.modules.battery.interval);
+  }, settings.modules.battery.interval);
 }
 
 exports.getSystemInfo = (callback) => {

--- a/server/db/postgres.js
+++ b/server/db/postgres.js
@@ -1,22 +1,22 @@
 const massive = require('massive'),
       app = require('../index'),
+      settings = app.locals.settings.config,
       winston = require('../services/winston'),
-      settings = require('../services/settings'),
       request = require('request');
 
-if (settings.config.db.postgres.status) {
-  if (!settings.config.db.postgres.host) winston.log.info('Using default PostgreSQL host.');
-  if (!settings.config.db.postgres.user) winston.log.info('Using default PostgreSQL user.');
-  if (!settings.config.db.postgres.dbname) winston.log.info('Using default PostgreSQL database name.');
+if (settings.db.postgres.status) {
+  if (!settings.db.postgres.host) winston.log.info('Using default PostgreSQL host.');
+  if (!settings.db.postgres.user) winston.log.info('Using default PostgreSQL user.');
+  if (!settings.db.postgres.dbname) winston.log.info('Using default PostgreSQL database name.');
 
-  let port = settings.config.db.postgres.port,
+  let port = settings.db.postgres.port,
       portString = '';
   if (port !== 5432) portString = ':' + port.toString();
   mConfig = {
-    user: settings.config.db.postgres.user,
-    pass: settings.config.db.postgres.pass,
-    host: settings.config.db.postgres.host,
-    dbname: settings.config.db.postgres.dbname
+    user: settings.db.postgres.user,
+    pass: settings.db.postgres.pass,
+    host: settings.db.postgres.host,
+    dbname: settings.db.postgres.dbname
   }
 
   let connectionString = `postgres://${mConfig.user}:${mConfig.pass}@${mConfig.host}${portString}/${mConfig.dbname}`;
@@ -31,7 +31,7 @@ if (settings.config.db.postgres.status) {
     });
   } catch (err) {
     winston.log.error('PostgreSQL database input does not match any database at that address.', err);
-    settings.config.db.postgres.status = false;
+    settings.db.postgres.status = false;
   }
 
   const massiveInstance = massive.connectSync({

--- a/server/db/pouchdb.js
+++ b/server/db/pouchdb.js
@@ -1,20 +1,20 @@
 const PouchDB = require('pouchdb'),
       winston = require('../services/winston'),
       app = require('../index'),
-      settings = require('../services/settings'),
+      settings = app.locals.settings.config,
       request = require('request');
 
-if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+if (settings.db.pouchdb.status || settings.db.couchdb.status) {
   let database = 'graphicdb';
-  if (settings.config.db.couchdb.status && !settings.config.db.pouchdb.status) {
-    let couch = settings.config.db.couchdb;
+  if (settings.db.couchdb.status && !settings.db.pouchdb.status) {
+    let couch = settings.db.couchdb;
     database = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + couch.port.toString() +'/'+ (couch.dbname ? couch.dbname : 'graphicdb');
     request.put(database, (err, res, body) => {
       if (err && err === 'file_exists') winston.log.info('Confirmed CouchDB database');
       if (err && err !== 'file_exists') winston.log.error('Could not create CouchDB database...', err);
     });
   }
-  winston.log.info('Connecting to', (settings.config.db.couchdb.status ? 'CouchDB':'PouchDB'), database);
+  winston.log.info('Connecting to', (settings.db.couchdb.status ? 'CouchDB':'PouchDB'), database);
 
   if (true) {
 

--- a/server/db/rethinkdb.js
+++ b/server/db/rethinkdb.js
@@ -1,8 +1,9 @@
 // const r = require('rethinkdb'),
 //       settings = require('../services/settings'),
-//       app = require('../index');
+//       app = require('../index'),
+//       settings = app.locals.settings.config,
 //
-// if (settings.config.db.rethinkdb.status) {
+// if (settings.db.rethinkdb.status) {
 //   rdbConfig = {
 //       rethinkdb: {
 //           host: "localhost",

--- a/server/endpoints/deletePouchDb.js
+++ b/server/endpoints/deletePouchDb.js
@@ -1,5 +1,4 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       pouchdb = require('../db/pouchdb');
 
 exports.destroyPouchDb = (req, response) => {

--- a/server/endpoints/getCpu.js
+++ b/server/endpoints/getCpu.js
@@ -1,27 +1,27 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       cpu = require('../controllers/cpu'),
       request = require('request'),
       app = require('../index'),
       db = app.get('db'),
+      settings = app.locals.settings.config,
       postgres = require('../db/postgres');
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getCpuData = (req, response) => {
   let module = 'cpu';
-  if (!settings.config.modules.cpu.status) {
+  if (!settings.modules.cpu.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
-    res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+    response.status(200).send('Cannot GET...', module, 'data is turned off.');
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);
@@ -55,17 +55,17 @@ exports.getProcessLoad = (req, response) => {
 
 exports.getProcesses = (req, response) => {
   let module = 'processes';
-  if (!settings.config.modules.processes.status) {
+  if (!settings.modules.processes.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/endpoints/getDisk.js
+++ b/server/endpoints/getDisk.js
@@ -1,25 +1,25 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       request = require('request'),
       app = require('../index'),
-      db = app.get('db');
+      db = app.get('db'),
+      settings = app.locals.settings.config;
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getDiskData = (req, response) => {
   let module = 'disk';
-  if (!settings.config.modules.fan.status) {
+  if (!settings.modules.fan.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     response.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);
@@ -33,17 +33,17 @@ exports.getDiskData = (req, response) => {
 
 exports.getDiskfsData = (req, res) => {
   let module = 'diskfs';
-  if (!settings.config.modules.fan.status) {
+  if (!settings.modules.fan.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/endpoints/getMemory.js
+++ b/server/endpoints/getMemory.js
@@ -1,25 +1,25 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       request = require('request'),
       app = require('../index'),
-      db = app.get('db');
+      db = app.get('db'),
+      settings = app.locals.settings.config;
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getMemoryData = (req, response) => {
   let module = 'memory';
-  if (!settings.config.modules.memory.status) {
+  if (!settings.modules.memory.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     response.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/endpoints/getNetwork.js
+++ b/server/endpoints/getNetwork.js
@@ -1,26 +1,26 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       network = require('../controllers/network'),
       request = require('request'),
       app = require('../index'),
-      db = app.get('db');
+      db = app.get('db'),
+      settings = app.locals.settings.config;
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getNetworkData = (req, response) => {
   let module = 'network';
-  if (!settings.config.modules.network.status) {
+  if (!settings.modules.network.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     response.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);
@@ -34,17 +34,17 @@ exports.getNetworkData = (req, response) => {
 
 exports.getNetConnections = (req, response) => {
   let module = 'netConnections';
-  if (!settings.config.modules.netConnections.status) {
+  if (!settings.modules.netConnections.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/endpoints/getSystem.js
+++ b/server/endpoints/getSystem.js
@@ -1,40 +1,36 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       app = require('../index'),
       system = require('../controllers/system'),
       request = require('request'),
-      db = app.get('db');
+      db = app.get('db'),
+      settings = app.locals.settings.config;
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getSystemInfo = (req, response) => {
-  // if (!settings.config.modules.system.status) {
-  //   res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  // } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
-    system.getSystemInfo()
-      .then(res => {
-        response.status(200).send(res);
-      })
-      .catch(err => {
-        winston.log.error('Error getting system information...', err);
-        response.status(500).send(err);
-      });
-  // }
+  system.getSystemInfo()
+    .then(res => {
+      response.status(200).send(res);
+    })
+    .catch(err => {
+      winston.log.error('Error getting system information...', err);
+      response.status(500).send(err);
+    });
 }
 
 exports.getBatteryData = (req, response) => {
   let module = 'battery';
-  if (!settings.config.modules.battery.status) {
+  if (!settings.modules.battery.status) {
     response.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/endpoints/getTemperature.js
+++ b/server/endpoints/getTemperature.js
@@ -1,25 +1,25 @@
 const winston = require('../services/winston'),
-      settings = require('../services/settings'),
       request = require('request'),
       app = require('../index'),
-      db = app.get('db');
+      db = app.get('db'),
+      settings = app.locals.settings.config;
 
-let couch = settings.config.db.couchdb,
-    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.config.port).toString() + (settings.config.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
+let couch = settings.db.couchdb,
+    xouchdbUrl = (couch.ssl ? 'https://' : 'http://') +couch.host+ ':' + (couch.status ? couch.port : settings.port).toString() + (settings.db.pouchdb.status ? '/pouch/' : '/') + (couch.dbname ? couch.dbname : 'graphicdb');
 
 exports.getTemperatureData = (req, response) => {
   let module = 'temperature';
-  if (!settings.config.modules.temperature.status) {
+  if (!settings.modules.temperature.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     response.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);
@@ -33,17 +33,17 @@ exports.getTemperatureData = (req, response) => {
 
 exports.getFanData = (req, response) => {
   let module = 'fan';
-  if (!settings.config.modules.fan.status) {
+  if (!settings.modules.fan.status) {
     winston.log.error('Attempted to get', module, 'but data for that module is turned off');
     res.status(200).send('Cannot GET...', module, 'data is turned off.');
-  } else if (settings.config.db.pouchdb.status || settings.config.db.couchdb.status) {
+  } else if (settings.db.pouchdb.status || settings.db.couchdb.status) {
     let dbUrl = xouchdbUrl +'/_design/' + module + '/_view/' + req.params.time;
     request.get(dbUrl, (err, res) => {
       if (err) winston.log.error('Error getting', module, 'from PouchDB/CouchDB...', err);
       winston.log.info('Data retreived from PouchDB/CouchDB for', module);
       response.status(200).send(res);
     });
-  } else if (settings.config.db.postgres.status) {
+  } else if (settings.db.postgres.status) {
     db.run(postgres.getQuery(req.params.time), [module+'%'], (err, res) => {
       if (err) {
         winston.log.error('Error getting', module, 'from Postgres...', err);

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ import webpackHotMiddleware from 'webpack-hot-middleware';
 import { spawn } from 'child_process';
 
 const app = express();
+app.set('config', settings.config);
 if (process.env.NODE_ENV === 'development') {
   const compiler = webpack(config),
         wdm = webpackDevMiddleware(compiler, {

--- a/server/services/settings.js
+++ b/server/services/settings.js
@@ -40,7 +40,8 @@ if (!fs.existsSync(configFile)) {
 }
 
 exports.putSettings = (req, res) => {
-  var appSettings = req.body;
+  const app = require('../index');
+  let appSettings = req.body;
   let saveConfig = JSON.stringify(appSettings, null, 4);
   try {
     fs.writeFileSync(configFile, saveConfig);
@@ -50,6 +51,7 @@ exports.putSettings = (req, res) => {
     console.error(`Could not save settings. ${err}`);
     rs.status(504).send(`Could not save settings. ${err}`);
   }
+  app.set('config', appSettings);
 };
 
 var loadConfig = fs.readFileSync(configFile), appSettings;
@@ -72,7 +74,8 @@ catch (err) {
 }
 
 exports.getSettings = (req, res) => {
-  res.status(200).send(appSettings);
+  const app = require('../index');
+  res.status(200).send(app.locals.settings.config);
 }
 
 exports.config = appSettings;

--- a/server/services/winston.js
+++ b/server/services/winston.js
@@ -1,25 +1,22 @@
 const winston = require('winston'),
       fs = require('fs'),
-      settings = require('../services/settings');
+      // app = require('../index'),
+      settings = require('./settings');
 
 const logDir = 'logs';
 if (!fs.existsSync(logDir)) fs.mkdirSync(logDir);
-
-const tsFormat = () => (new Date()).toLocaleTimeString();
 
 const logLevel = settings.config.logLevel;
 // levels: { error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5 }
 exports.log = new (winston.Logger)({
   transports: [
     new (winston.transports.Console)({
-      timestamp: tsFormat,
       colorize: true,
       level: 'warn'
     }),
     new (winston.transports.File)({
       filename: `${logDir}/log.log`,
       level: logLevel,
-      // timestamp: tsFormat
     })
   ]
 });


### PR DESCRIPTION
This is a fix where variables representing the object settings weren't being updated with a put request. I've implemented express' `app.locals.settings` for accessing mutable local variables in node which apply conditions for turning on/off application states managed by our app's settings.